### PR TITLE
support for try-files and not-found-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ This action requires the upload directory to be already available so you will ne
 
 Find out more about github token from [documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow).
 
+### `try-files`
+
+Default value: `index.html`
+
+Define a list of space separated files that portal should try to serve in if uri points to a directory, ie `index.html /index.html`.
+
+### `not-found-page`
+
+Define a path to a file that will replace the default 404 Not Found error page, ie `404.html`.
+
 ### `registry-seed`
 
 You can provide a seed (keep it secret, keep it safe) and this action will set corresponding skynet registry entry value to the deployed resolver skylink.

--- a/action.yml
+++ b/action.yml
@@ -1,35 +1,42 @@
-name: 'Skynet Deploy'
-description: 'Deploy your static webapp to Skynet'
+name: "Skynet Deploy"
+description: "Deploy your static webapp to Skynet"
 branding:
-  icon: 'cloud'
-  color: 'green'
+  icon: "cloud"
+  color: "green"
 inputs:
   upload-dir:
-    description: 'Directory to upload'
+    description: "Directory to upload"
     required: true
   github-token:
-    description: 'Github token used for including the skylink url in pull request'
+    description: "Github token used for including the skylink url in pull request"
     required: true
+  try-files:
+    description: "Define a list of space separated files that portal should try to serve in if uri points to a directory"
+    required: false
+    default: "index.html"
+  not-found-page:
+    description: "Define a path to a file that will replace the default 404 Not Found error page"
+    required: false
   registry-seed:
-    description: 'Seed that generates registry private key (optional, only if you want to update the registry entry with skylink)'
+    description: "Seed that generates registry private key (optional, only if you want to update the registry entry with skylink)"
     required: false
   registry-datakey:
-    description: 'Registry datakey to use when updating the registry entry'
+    description: "Registry datakey to use when updating the registry entry"
     required: true
-    default: 'skylink.txt'
+    default: "skylink.txt"
   portal-url:
-    description: 'Skynet portal api url'
+    description: "Skynet portal api url"
     required: true
-    default: 'https://siasky.net'
+    default: "https://siasky.net"
 outputs:
   skylink:
-    description: 'Uploaded resource skylink'
+    description: "Uploaded resource skylink"
   skylink-url:
-    description: 'Uploaded resource skylink url'
+    description: "Uploaded resource skylink url"
   resolver-skylink:
-    description: 'Resolver skylink pointing to uploaded resource'
+    description: "Resolver skylink pointing to uploaded resource"
   resolver-skylink-url:
-    description: 'Resolver skylink url (as a subdomain)'
+    description: "Resolver skylink url (as a subdomain)"
 runs:
-  using: 'node12'
+  using: "node12"
   main: index.js

--- a/index.js
+++ b/index.js
@@ -15,13 +15,40 @@ function outputAxiosErrorMessage(error) {
   }
 }
 
+function prepareUploadOptions() {
+  const options = {};
+
+  if (core.getInput("try-files")) {
+    try {
+      options.tryfiles = encodeURIComponent(
+        JSON.stringify(core.getInput("try-files").split(/\s+/))
+      );
+    } catch (error) {
+      throw new Error(`tryfiles input parsing error: ${error.message}`);
+    }
+  }
+
+  if (core.getInput("not-found-page")) {
+    try {
+      options.errorpages = encodeURIComponent(
+        JSON.stringify({ 404: core.getInput("not-found-page") })
+      );
+    } catch (error) {
+      throw new Error(`not-found-page input parsing error: ${error.message}`);
+    }
+  }
+
+  return options;
+}
+
 (async () => {
   try {
     // upload to skynet
     const nodeClient = new NodeSkynetClient(core.getInput("portal-url"));
     const skynetClient = new SkynetClient(core.getInput("portal-url"));
     const skylink = await nodeClient.uploadDirectory(
-      core.getInput("upload-dir")
+      core.getInput("upload-dir"),
+      prepareUploadOptions()
     );
 
     // generate base32 skylink url from base64 skylink


### PR DESCRIPTION
Add support for 2 new directory upload options:
- **try-files** - define a list of space separated files that portal should try to serve in if uri points to a directory
- **not-found-page** - define a path to a file that will replace the default 404 Not Found error page